### PR TITLE
feature/cpu-monitor

### DIFF
--- a/cpu-monitor.sh
+++ b/cpu-monitor.sh
@@ -1,8 +1,31 @@
 #!/bin/bash
 
+usage="Usage: $0 <program_name:str> [threshold:flt]"
+
+if [[ $# -lt 1 ]]; then
+    echo "$0 requires at least 1 argument"
+    echo
+    echo $usage
+
+    exit 1
+fi
+
+if ! pgrep "$1" > /dev/null; then
+  echo "Error: Can't find an active process named '$1'"
+
+  exit 1
+fi
+
+if [[ -n "$2" ]] && (( $(echo "$2 <= 0.009" | bc -l) )); then
+    echo "Error: Threshold value must be at least 0.01"
+    echo
+    echo $usage
+
+    exit 1
+fi
+
 program_name=$1
 threshold=${2:-100}
-
 logfile="logfile.txt"
 
 if [ -e "$logfile" ]; then
@@ -20,7 +43,7 @@ echo >> $logfile
 count=0
 over_threshold=false
 
-for (( ; ; )); do
+while true; do
     cpu_usage=$(top -b -n 1 | grep -m1 $program_name | awk '{printf $9}')
 
     if (( $(echo "$cpu_usage >= $threshold" | bc -l) )); then

--- a/cpu-monitor.sh
+++ b/cpu-monitor.sh
@@ -2,7 +2,7 @@
 
 program_name=$1
 
-echo "CPU threshold monitor for $program_name running"
+echo -e "CPU threshold monitor for $program_name running being written to \e]8;;file://$(pwd)/logfile.txt\alogfile.txt\e]8;;\a"
 echo
 
 echo "CPU threshold monitor for $program_name [$(date '+%Y-%m-%d %H:%M:%S')]:" >> logfile.txt

--- a/cpu-monitor.sh
+++ b/cpu-monitor.sh
@@ -2,15 +2,17 @@
 
 program_name=$1
 
-echo -e "CPU threshold monitor for $program_name running being written to \e]8;;file://$(pwd)/logfile.txt\alogfile.txt\e]8;;\a"
+logfile="logfile.txt"
+
+echo -e "CPU threshold monitor for $program_name running being written to \e]8;;file://$(pwd)/$logfile\a$logfile\e]8;;\a"
 echo
 
-echo "CPU threshold monitor for $program_name [$(date '+%Y-%m-%d %H:%M:%S')]:" >> logfile.txt
-echo >> logfile.txt
+echo "CPU threshold monitor for $program_name [$(date '+%Y-%m-%d %H:%M:%S')]:" >> $logfile
+echo >> $logfile
 
 
 while true; do
-    echo "$(top -b -n1 | grep -m1 $program_name | awk '{printf "%.2f%%\n", $9}')"
+    top -b -n 1 | grep -m1 $program_name | awk '{printf "%.2f%%\n", $9}' >> logfile.txt
 
     sleep 60
 done

--- a/cpu-monitor.sh
+++ b/cpu-monitor.sh
@@ -10,14 +10,33 @@ if [ -e "$logfile" ]; then
 fi
 
 echo -e "CPU threshold monitor for $program_name running being written to \e]8;;file://$(pwd)/$logfile\a$logfile\e]8;;\a"
-echo
 
 echo "CPU threshold monitor for $program_name [$(date '+%Y-%m-%d %H:%M:%S')]:" >> $logfile
 echo >> $logfile
 
+count=0
+threshold=100
+over_threshold=false
 
-while true; do
-    top -b -n 1 | grep -m1 $program_name | awk '{printf "%.2f%%\n", $9}' >> logfile.txt
+for (( ; ; )); do
+    cpu_usage=$(top -b -n 1 | grep -m1 $program_name | awk '{printf $9}')
 
-    sleep 60
+    if (( $(echo "$cpu_usage >= $threshold" | bc -l) )); then
+        ((count++))
+
+        if (( $count % 5 == 0 && !$over_threshold )); then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] CPU usage over $threshold% for more than $count seconds" >> logfile.txt
+            over_threshold=true
+        fi
+    else
+        count=0
+
+        if $over_threshold; then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] CPU usage dropped below 100%" >> logfile.txt
+            echo >> logfile.txt
+            over_threshold=false
+        fi
+    fi
+
+    sleep 1
 done

--- a/cpu-monitor.sh
+++ b/cpu-monitor.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+program_name=$1
+
+echo "CPU threshold monitor for $program_name running"
+echo
+
+while true; do
+    echo "$(top -b -n1 | grep -m1 $program_name | awk '{printf "%.2f%%\n", $9}')"
+
+    sleep 60
+done

--- a/cpu-monitor.sh
+++ b/cpu-monitor.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 program_name=$1
+threshold=${2:-100}
 
 logfile="logfile.txt"
 
@@ -10,12 +11,13 @@ if [ -e "$logfile" ]; then
 fi
 
 echo -e "CPU threshold monitor for $program_name running being written to \e]8;;file://$(pwd)/$logfile\a$logfile\e]8;;\a"
+echo "Usage will be logged where it exceeds $threshold% for a minimum of 5 seconds"
 
 echo "CPU threshold monitor for $program_name [$(date '+%Y-%m-%d %H:%M:%S')]:" >> $logfile
+echo "Usage will be logged where it exceeds $threshold% for a minimum of 5 seconds" >> $logfile
 echo >> $logfile
 
 count=0
-threshold=100
 over_threshold=false
 
 for (( ; ; )); do
@@ -32,7 +34,7 @@ for (( ; ; )); do
         count=0
 
         if $over_threshold; then
-            echo "[$(date '+%Y-%m-%d %H:%M:%S')] CPU usage dropped below 100%" >> logfile.txt
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] CPU usage dropped below $threshold%" >> logfile.txt
             echo >> logfile.txt
             over_threshold=false
         fi

--- a/cpu-monitor.sh
+++ b/cpu-monitor.sh
@@ -4,6 +4,11 @@ program_name=$1
 
 logfile="logfile.txt"
 
+if [ -e "$logfile" ]; then
+    echo "-----" >> $logfile
+    echo >> $logfile
+fi
+
 echo -e "CPU threshold monitor for $program_name running being written to \e]8;;file://$(pwd)/$logfile\a$logfile\e]8;;\a"
 echo
 

--- a/cpu-monitor.sh
+++ b/cpu-monitor.sh
@@ -5,6 +5,10 @@ program_name=$1
 echo "CPU threshold monitor for $program_name running"
 echo
 
+echo "CPU threshold monitor for $program_name [$(date '+%Y-%m-%d %H:%M:%S')]:" >> logfile.txt
+echo >> logfile.txt
+
+
 while true; do
     echo "$(top -b -n1 | grep -m1 $program_name | awk '{printf "%.2f%%\n", $9}')"
 


### PR DESCRIPTION
test: 

- run `./cpu-monitor.sh <program_name>`, defaults threshold to 100%
- run `./cpu-monitor.sh <program_name>`, 25, sets threshold to 25%

if program exceeds threshold for more than 5s, starts writing to logfile on each 5s increment

test cli arg validation: 

- run `./cpu-monitor.sh`, errors that at least 1 arg required
- run `./cpu-monitor.sh <process_that_is_not_running`, errors that process not found
- run `./cpu-monitor.sh <program_name> 0.009`, errors that threshold must be a number at least 0.01
- run `./cpu-monitor.sh <program_name> xyz`, errors that threshold must be a number at least 0.01
